### PR TITLE
Remove spf13 dependency and use builtin flag package

### DIFF
--- a/cmd/gdmd/main.go
+++ b/cmd/gdmd/main.go
@@ -1,11 +1,10 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"os"
 	"path/filepath"
-
-	flag "github.com/spf13/pflag"
 )
 
 const (
@@ -18,9 +17,9 @@ options:`
 )
 
 func main() {
-	hFlag := flag.BoolP("help", "h", false, "print this help message")
-	vFlag := flag.BoolP("version", "v", false, "print version")
-	rFlag := flag.BoolP("recursive", "r", false, "walk directories recursively")
+	hFlag := flag.Bool("help", false, "print this help message")
+	vFlag := flag.Bool("v", false, "print version")
+	rFlag := flag.Bool("r", false, "walk directories recursively")
 
 	flag.Parse()
 

--- a/cmd/gdmd/markdown.tmpl
+++ b/cmd/gdmd/markdown.tmpl
@@ -1,3 +1,4 @@
+{{- /* gotype: github.com/chocolacula/gdmd/cmd/gdmd.Package */ -}}
 # Overview
 
 package `{{ .Name }}`

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,5 @@ require github.com/stretchr/testify v1.9.0
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,9 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This pull request includes several changes to the `cmd/gdmd` project, focusing on simplifying the codebase by removing an external dependency and updating flag handling. Additionally, a template file was updated with a new comment.

Codebase simplification:

* [`cmd/gdmd/main.go`](diffhunk://#diff-44ef6fe57c0c262fa32773dee8f4e4a183cafdbbe7bf432cf8f50dc4e1624c8eR4-L8): Removed the `github.com/spf13/pflag` dependency and replaced it with the standard library `flag` package. Updated the flag definitions to use the standard `flag` package. [[1]](diffhunk://#diff-44ef6fe57c0c262fa32773dee8f4e4a183cafdbbe7bf432cf8f50dc4e1624c8eR4-L8) [[2]](diffhunk://#diff-44ef6fe57c0c262fa32773dee8f4e4a183cafdbbe7bf432cf8f50dc4e1624c8eL21-R22)
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L10): Removed the `github.com/spf13/pflag` dependency.

Template update:

* [`cmd/gdmd/markdown.tmpl`](diffhunk://#diff-d777695f1b4e3d548a9cd5fa5f96a5a4a6a0666d0b85bf1669423e7c3503c28bR1): Added a comment indicating the Go type associated with the template.